### PR TITLE
Add publishing components

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ gem "rails", "~> 7.0.7"
 gem "bootsnap", require: false
 gem "devise"
 gem "govuk_app_config"
+gem "govuk_publishing_components"
 gem "jbuilder"
+gem "sassc-rails"
 gem "sprockets-rails"
 gem "sqlite3", "~> 1.4"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-protobuf (3.24.0-arm64-darwin)
@@ -120,6 +121,17 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
+    govuk_personalisation (0.14.0)
+      plek (>= 1.9.0)
+      rails (>= 6, < 8)
+    govuk_publishing_components (35.14.0)
+      govuk_app_config
+      govuk_personalisation (>= 0.7.0)
+      kramdown
+      plek
+      rails (>= 6)
+      rouge
+      sprockets (>= 3)
     govuk_test (3.0.1)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -131,6 +143,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    kramdown (2.4.0)
+      rexml
     language_server-protocol (3.17.0.3)
     logstasher (2.1.5)
       activesupport (>= 5.2)
@@ -411,6 +425,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    rouge (4.1.3)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -464,6 +479,14 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -489,6 +512,7 @@ GEM
     sqlite3 (1.6.3-arm64-darwin)
     statsd-ruby (1.5.0)
     thor (1.2.2)
+    tilt (2.2.0)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -517,12 +541,14 @@ DEPENDENCIES
   devise
   factory_bot_rails
   govuk_app_config
+  govuk_publishing_components
   govuk_test
   jbuilder
   pry-byebug
   rails (~> 7.0.7)
   rspec-rails
   rubocop-govuk
+  sassc-rails
   simplecov
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,4 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link application.scss
+//= link application.js
+//= link application.css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,1 @@
+//= require govuk_publishing_components/lib

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,2 @@
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/layout-header

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,5 @@
  
  @import 'govuk_publishing_components/govuk_frontend_support';
  @import 'govuk_publishing_components/component_support';
+ @import 'govuk_publishing_components/components/layout-header';
+ @import 'govuk_publishing_components/components/search';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,6 @@
  *= require_tree .
  *= require_self
  */
+ 
+ @import 'govuk_publishing_components/govuk_frontend_support';
+ @import 'govuk_publishing_components/component_support';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,14 @@
   </head>
 
   <body>
-    <%= yield %>
+    <%= render "govuk_publishing_components/components/layout_header", {
+      product_name: "Holiday Logger"
+    } %>
+
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper">
+        <%= yield %>
+      </main>
+    </div>
   </body>
 </html>

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,5 @@
+GovukPublishingComponents.configure do |c|
+  c.component_guide_title = "My component guide"
+  c.application_stylesheet = "application" # Defaults to "application", set to `nil` if the application stylesheet is not in use
+  c.application_javascript = "application" # Defaults to "application"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,6 @@ Rails.application.routes.draw do
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+
+  mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 end


### PR DESCRIPTION
## What
Adds the `govuk_publishing_components` gem to the project and makes use of the layout header component 

## Why
The project will be using this gem for its views to ensure consistent styling and accessibility