### PR TITLE
Fix RSpec GitHub Actions workflow

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -31,6 +31,9 @@ jobs:
 
     - name: Setup database
       run: rake db:test:prepare
+
+    - name: Precomiple assets
+      run: rake assets:precompile
       
     - name: Run RSpec
       run: bundle exec rspec


### PR DESCRIPTION
## What
This adds precompilation of assets to the RSpec GitHub Actions workflow

## Why
The RSpec GitHub Actions workflow failed when merged to main. I suspected this was because assets weren't precompiling before running tests.