### PR TITLE
Install and set up Buildkite Test Analytics

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -10,6 +10,9 @@ on:
         description: 'The branch, tag or SHA to checkout'
         required: false
         type: string
+    secrets:
+      BUILDKITE_ANALYTICS_TOKEN:
+        required: true
 
   pull_request:
 
@@ -17,6 +20,8 @@ jobs:
   run-rspec:
     runs-on: ubuntu-latest
     name: Run RSpec
+    env:
+      BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
 end
 
 group :test do
+  gem "buildkite-test_collector"
   gem "simplecov"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       msgpack (~> 1.2)
     brakeman (6.0.1)
     builder (3.2.4)
+    buildkite-test_collector (2.3.1)
+      activesupport (>= 4.2)
     byebug (11.1.3)
     capybara (3.39.2)
       addressable
@@ -543,6 +545,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  buildkite-test_collector
   devise
   factory_bot_rails
   govuk_app_config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,3 +15,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
 end
+
+require "buildkite/test_collector"
+
+Buildkite::TestCollector.configure(hook: :rspec)


### PR DESCRIPTION
## What
- Adds integration with Buildkite's Test Analytics

## Why
This can help identify flaky or slow tests and hence improve the performance of the test suite.

## Screenshots
The following image shows that the changes made in this PR have resulted in test suite data being ported into Buildkite's Test Analytics.

![image](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/26c1e34f-d479-4cf1-b7f6-f29599cfa715)
