### PR TITLE
Update sign in view design

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ application up and running.
 
 Things you may want to cover:
 
-* Ruby version
+*  Ruby version
 
-* System dependencies
+*  System dependencies
 
-* Configuration
+*  Configuration
 
-* Database creation
+*  Database creation
 
-* Database initialization
+*  Database initialization
 
-* How to run the test suite
+*  How to run the test suite
 
-* Services (job queues, cache servers, search engines, etc.)
+*  Services (job queues, cache servers, search engines, etc.)
 
-* Deployment instructions
+*  Deployment instructions
 
-* ...
+*  ...

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,3 @@
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/layout-header

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,12 @@
  */
  
  @import 'govuk_publishing_components/govuk_frontend_support';
- @import 'govuk_publishing_components/component_support';
- @import 'govuk_publishing_components/components/layout-header';
- @import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/component_support';
+@import 'govuk_publishing_components/components/button';
+@import 'govuk_publishing_components/components/error-message';
+@import 'govuk_publishing_components/components/hint';
+@import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/components/title';

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,39 @@
-<h2>Sign in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      title: "Sign in to GOV.UK Holiday Logger",
+      average_title_length: "long",
+      margin_top: 0
+    } %>
   </div>
+</div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Email"
+        },
+        name: "user[email]",
+        type: "email"
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Password"
+        },
+        name: "user[password]",
+        type: "password"
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Sign in"
+      } %>
+    <% end %>
+
+    <p class="govuk-body govuk-!-margin-top-5">
+      <%= link_to t('devise.links.forgot_password'), new_password_path(resource_name), class: "govuk-link" %>
+    </p>
   </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Sign in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/spec/features/sessions/sign_in_spec.rb
+++ b/spec/features/sessions/sign_in_spec.rb
@@ -16,7 +16,7 @@ end
 
 def when_i_go_to_the_sign_in_page
   visit new_user_session_path
-  expect(page).to have_content("Sign in")
+  expect(page).to have_content("Sign in to GOV.UK Holiday Logger")
 end
 
 def and_i_fill_in_the_sign_in_form


### PR DESCRIPTION
## What
Updates the `sign_in` view to use components from the `govuk_publishing_components` gem.

## Why
The view was previously using the `devise` gem's out-of-the-box solution. Now that the `govuk_publishing_components` gem is installed in the project, we can make update the view to match the design specification.

## Screenshots
### Before
![localhost_3000_users_sign_in(iPad Pro) (1)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/6056bd19-95c7-4d79-acee-b62f5b26b78a)

### After
![localhost_3000_users_sign_in(iPad Pro) (2)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/2b62d0c1-d980-43da-9009-f27d6bd2ded9)

### Design specification
![localhost_3000_sign-in(iPad Pro) (1)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/cc3829e1-feeb-4f11-a16c-43008d78c888)

