### PR TITLE
Update root#index view and layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "govuk_test"
   gem "pry-byebug"
+  gem "rails-controller-testing"
   gem "rspec-rails"
   gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,6 +407,10 @@ GEM
       activesupport (= 7.0.7)
       bundler (>= 1.15.0)
       railties (= 7.0.7)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -554,6 +558,7 @@ DEPENDENCIES
   jbuilder
   pry-byebug
   rails (~> 7.0.7)
+  rails-controller-testing
   rspec-rails
   rubocop-govuk
   sassc-rails

--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ application up and running.
 
 Things you may want to cover:
 
-*  Ruby version
+*   Ruby version
 
-*  System dependencies
+*   System dependencies
 
-*  Configuration
+*   Configuration
 
-*  Database creation
+*   Database creation
 
-*  Database initialization
+*   Database initialization
 
-*  How to run the test suite
+*   How to run the test suite
 
-*  Services (job queues, cache servers, search engines, etc.)
+*   Services (job queues, cache servers, search engines, etc.)
 
-*  Deployment instructions
+*   Deployment instructions
 
-*  ...
+*   ...

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,3 +1,5 @@
 class RootController < ApplicationController
-  def index; end
+  def index
+    redirect_to new_user_session_path unless current_user
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,21 @@
   </head>
 
   <body>
-    <%= render "govuk_publishing_components/components/layout_header", {
-      product_name: "Holiday Logger"
-    } %>
+    <% if current_user %>
+      <%= render "govuk_publishing_components/components/layout_header", {
+        product_name: "Holiday Logger",
+        navigation_items: [
+          {
+            text: "Sign out",
+            href: destroy_user_session_path
+          }
+        ]
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/layout_header", {
+        product_name: "Holiday Logger"
+      } %>
+    <% end %>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper">

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,9 +1,7 @@
-<h1>Root#index</h1>
-<p>Find me in app/views/root/index.html.erb</p>
-
 <% if current_user %>
-  <h1> <%= "#{current_user.given_name} #{current_user.family_name}'s Dashboard" %> </h1>
-  <%= button_to "Sign out", destroy_user_session_path, method: :delete%>
-<% else %>
-  <%= link_to "Sign in", new_user_session_path %>
+  <%= render "govuk_publishing_components/components/title", {
+    title: "#{current_user.given_name} #{current_user.family_name}'s Dashboard",
+    average_title_length: "long",
+    margin_top: 0
+  } %>
 <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,7 +266,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe RootController do
+  describe "GET index" do
+    it "redirects if user is not signed in" do
+      get :index
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "renders the index page if user is signed in" do
+      sign_in create(:user)
+      get :index
+      expect(response).to render_template("index")
+    end
+  end
+end

--- a/spec/features/sessions/sign_out_spec.rb
+++ b/spec/features/sessions/sign_out_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.feature "Sign out" do
   scenario do
     given_i_am_signed_in
-    when_i_click_the_sign_out_button
+    when_i_click_the_sign_out_link
     then_i_am_successfully_signed_out
   end
 end
@@ -18,11 +18,12 @@ def given_i_am_signed_in
   expect(page).to have_content("#{@user.given_name} #{@user.family_name}'s Dashboard")
 end
 
-def when_i_click_the_sign_out_button
-  click_button "Sign out"
+def when_i_click_the_sign_out_link
+  click_link "Sign out"
 end
 
 def then_i_am_successfully_signed_out
   visit root_path
-  expect(page).not_to have_content("#{@user.given_name} #{@usfamily}'s Dashboard")
+  expect(page).to have_content("Sign in to GOV.UK Holiday Logger")
+  expect(page).to have_current_path("/users/sign_in")
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 GovukTest.configure
 
 RSpec.configure do |config|
+  config.include Devise::TestHelpers, type: :controller
   config.include FactoryBot::Syntax::Methods
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
## What
- Updates the application layout to include a navigation bar when the user is logged in
- Re-routes users from the root#index view to the sign in page when not logged in
- Updates the root#index view to include `govuk_publishing_components` components and bring it in line with design specification

## Why
- The `root#index` view did not accurately represent the design specification. Now that the `govuk_publishing_components` gem is installed in the project, we can update the view to match the design specification.

## Screenshots
### Before
![localhost_3000_(iPad Pro) (1)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/c4d72441-5021-47db-b25f-d7b10d4170c4)

### After
![localhost_3000_(iPad Pro)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/1295def8-98aa-4461-93fe-2684ccfb3e71)

### Design specification
![localhost_3000_dashboard(iPad Pro) (2)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/c73085ea-9574-4587-bdb6-3be6fd4af484)

