### PR TITLE
Feature: User can view annual leave

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,7 @@
  *= require_self
  */
  
- @import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/error-message';
@@ -22,5 +22,6 @@
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/panel';
 @import 'govuk_publishing_components/components/search';
 @import 'govuk_publishing_components/components/title';

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -4,4 +4,9 @@
     average_title_length: "long",
     margin_top: 0
   } %>
+
+  <%= render "govuk_publishing_components/components/panel", {
+    prepend: "Annual leave balance",
+    title: "#{current_user.annual_leave_remaining} days"
+  } %>
 <% end %>

--- a/db/migrate/20230825114919_add_annual_leave_remaining_to_users.rb
+++ b/db/migrate/20230825114919_add_annual_leave_remaining_to_users.rb
@@ -1,0 +1,5 @@
+class AddAnnualLeaveRemainingToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :annual_leave_remaining, :decimal, precision: 3, scale: 1, null: false, default: 25
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_18_114648) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_25_114919) do
   create_table "users", force: :cascade do |t|
     t.string "given_name", null: false
     t.string "family_name", null: false
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_18_114648) do
     t.string "role", default: "user"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "annual_leave_remaining", precision: 3, scale: 1, default: "25.0", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     family_name { "Smith" }
     email { "john.smith@digital.cabinet-office.gov.uk" }
     password { "password with $ymb0l$" }
+    annual_leave_remaining { 27.5 }
   end
 end

--- a/spec/features/user/view_annual_leave_remaining_spec.rb
+++ b/spec/features/user/view_annual_leave_remaining_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.feature "User can view annual leave remaining" do
+  scenario do
+    given_i_have_sign_in_details
+    and_i_am_signed_in
+    when_i_visit_the_homepage
+    then_i_can_see_my_remaining_annual_leave_entitlement
+  end
+end
+
+def given_i_have_sign_in_details
+  @user = create(:user)
+end
+
+def and_i_am_signed_in
+  sign_in @user
+end
+
+def when_i_visit_the_homepage
+  visit root_path
+end
+
+def then_i_can_see_my_remaining_annual_leave_entitlement
+  expect(page).to have_content(@user.annual_leave_remaining)
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,8 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 GovukTest.configure
 
 RSpec.configure do |config|
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include FactoryBot::Syntax::Methods
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
## User story
```
As an employee of GDS
So that I can manage my remaining annual leave
I want to be able to see how many days of annual leave I have remaining this year.
```
## What
- Adds a `annual_leave_remaining` column to the `user` table.
- Implements the feature, with associated feature test

## Screenshots
### Before
![localhost_3000_(iPad Pro) (2)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/2a6419ba-1652-4b3d-bd12-08c6a05f6ed8)
### After
![localhost_3000_(iPad Pro) (3)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/f51fa389-7e9a-493d-8d55-dbcf78c977dd)
### Design specification
![localhost_3000_dashboard(iPad Pro) (2)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/56d7388a-10de-4afa-a4bc-33de19e87526)
