### PR TITLE
Add line manager dashboard

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/table

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,14 +14,15 @@
  *= require_self
  */
  
-@import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/component_support';
-@import 'govuk_publishing_components/components/button';
-@import 'govuk_publishing_components/components/error-message';
-@import 'govuk_publishing_components/components/hint';
-@import 'govuk_publishing_components/components/input';
-@import 'govuk_publishing_components/components/label';
-@import 'govuk_publishing_components/components/layout-header';
-@import 'govuk_publishing_components/components/panel';
-@import 'govuk_publishing_components/components/search';
-@import 'govuk_publishing_components/components/title';
+ @import 'govuk_publishing_components/govuk_frontend_support';
+ @import 'govuk_publishing_components/component_support';
+ @import 'govuk_publishing_components/components/button';
+ @import 'govuk_publishing_components/components/error-message';
+ @import 'govuk_publishing_components/components/hint';
+ @import 'govuk_publishing_components/components/input';
+ @import 'govuk_publishing_components/components/label';
+ @import 'govuk_publishing_components/components/layout-header';
+ @import 'govuk_publishing_components/components/panel';
+ @import 'govuk_publishing_components/components/search';
+ @import 'govuk_publishing_components/components/table';
+ @import 'govuk_publishing_components/components/title';

--- a/app/controllers/line_reports_controller.rb
+++ b/app/controllers/line_reports_controller.rb
@@ -1,0 +1,13 @@
+class LineReportsController < ApplicationController
+  before_action :redirect_if_user_not_line_manager
+
+  def show
+    @line_reports = current_user.line_reports
+  end
+
+private
+
+  def redirect_if_user_not_line_manager
+    redirect_to root_path unless current_user.is_line_manager?
+  end
+end

--- a/app/helpers/nav_bar_helper.rb
+++ b/app/helpers/nav_bar_helper.rb
@@ -1,0 +1,18 @@
+module NavBarHelper
+  def navigation_items
+    return [] unless current_user
+    
+    items = []
+
+    items << { text: "Your annual leave", href: root_path, active: is_current?(root_path) }
+    items << { text: "Sign out", href: destroy_user_session_path }
+    
+    items
+  end
+
+  def is_current?(link)
+    recognized = Rails.application.routes.recognize_path(link)
+    recognized[:controller] == params[:controller] &&
+      recognized[:action] == params[:action]
+  end
+end

--- a/app/helpers/nav_bar_helper.rb
+++ b/app/helpers/nav_bar_helper.rb
@@ -1,12 +1,26 @@
 module NavBarHelper
   def navigation_items
     return [] unless current_user
-    
+
     items = []
 
-    items << { text: "Your annual leave", href: root_path, active: is_current?(root_path) }
-    items << { text: "Sign out", href: destroy_user_session_path }
-    
+    items << {
+      text: "Your annual leave",
+      href: root_path,
+      active: is_current?(root_path),
+    }
+    if current_user.is_line_manager?
+      items << {
+        text: "Your line reports",
+        href: line_reports_path,
+        active: is_current?(line_reports_path),
+      }
+    end
+    items << {
+      text: "Sign out",
+      href: destroy_user_session_path,
+    }
+
     items
   end
 

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,0 +1,23 @@
+module UserHelper
+  def line_reports_table_rows(line_reports)
+    rows = []
+
+    line_reports.each do |line_report|
+      rows << [
+        {
+          text: "#{line_report.given_name} #{line_report.family_name}",
+        },
+        {
+          # TODO: Update this so that it says "Pending requests" if a line report has
+          # annual leave requests in "Pending" status and "No requests" if not.
+          text: sanitize("<strong class='govuk-tag'> PLACEHOLDER FOR STATUS </strong>"),
+        },
+        {
+          text: "Manage requests",
+        },
+      ]
+    end
+
+    rows
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,8 @@ class User < ApplicationRecord
   validates :given_name, presence: true
   validates :family_name, presence: true
   validates :password, length: { minimum: 8, message: "must be at least 8 characters long" }
+
+  def is_line_manager?
+    line_reports.any?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  has_many :line_reports, class_name: "User", foreign_key: "line_manager_id"
+  belongs_to :line_manager, class_name: "User", optional: true
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,21 +10,10 @@
   </head>
 
   <body>
-    <% if current_user %>
-      <%= render "govuk_publishing_components/components/layout_header", {
-        product_name: "Holiday Logger",
-        navigation_items: [
-          {
-            text: "Sign out",
-            href: destroy_user_session_path
-          }
-        ]
-      } %>
-    <% else %>
-      <%= render "govuk_publishing_components/components/layout_header", {
-        product_name: "Holiday Logger"
-      } %>
-    <% end %>
+    <%= render "govuk_publishing_components/components/layout_header", {
+      product_name: "Holiday Logger",
+      navigation_items: navigation_items
+    } %>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper">

--- a/app/views/line_reports/show.html.erb
+++ b/app/views/line_reports/show.html.erb
@@ -1,0 +1,20 @@
+<%= render "govuk_publishing_components/components/title", {
+    title: "#{current_user.given_name} #{current_user.family_name}'s Line Reports",
+    average_title_length: "long",
+    margin_top: 0
+  } %>
+
+<%= render "govuk_publishing_components/components/table", {
+  head: [
+    {
+      text: "Line Report"
+    },
+    {
+      text: "Status"
+    },
+    {
+      text: ""
+    }
+  ],
+  rows: line_reports_table_rows(@line_reports)
+} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
 
+  resource :line_reports, only: [:show]
+
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 end

--- a/db/migrate/20230825123530_add_line_manager_to_users.rb
+++ b/db/migrate/20230825123530_add_line_manager_to_users.rb
@@ -1,0 +1,7 @@
+class AddLineManagerToUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_table :users do |t|
+      t.references :line_manager, foreign_key: { to_table: :users }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_25_114919) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_25_123530) do
   create_table "users", force: :cascade do |t|
     t.string "given_name", null: false
     t.string "family_name", null: false
@@ -23,8 +23,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_25_114919) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "annual_leave_remaining", precision: 3, scale: 1, default: "25.0", null: false
+    t.integer "line_manager_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["line_manager_id"], name: "index_users_on_line_manager_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "users", "users", column: "line_manager_id"
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,8 +2,16 @@ FactoryBot.define do
   factory(:user) do
     given_name { "John" }
     family_name { "Smith" }
-    email { "john.smith@digital.cabinet-office.gov.uk" }
+    sequence(:email) { |n| "user-#{n}@digital.cabinet-office.gov.uk" }
     password { "password with $ymb0l$" }
     annual_leave_remaining { 27.5 }
+  end
+
+  trait(:line_manager) do
+    after(:create) do |line_manager|
+      3.times do |n|
+        create(:user, given_name: "LineReport", family_name: n.to_s, line_manager_id: line_manager.id)
+      end
+    end
   end
 end

--- a/spec/features/user/line_manager_dashboard_spec.rb
+++ b/spec/features/user/line_manager_dashboard_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.feature "Line manager can view their line reports on the line reports dashboard" do
+  scenario do
+    given_i_am_signed_in_as_a_line_manager
+    when_i_visit_the_homepage
+    and_i_click_the_line_reports_navbar_item
+    then_i_can_see_my_line_reports
+  end
+end
+
+def given_i_am_signed_in_as_a_line_manager
+  @line_manager = create(:user, :line_manager)
+  sign_in @line_manager
+end
+
+def when_i_visit_the_homepage
+  visit root_path
+end
+
+def and_i_click_the_line_reports_navbar_item
+  click_link "Your line reports"
+end
+
+def then_i_can_see_my_line_reports
+  expect(page).to have_content("LineReport 0")
+  expect(page).to have_content("LineReport 1")
+  expect(page).to have_content("LineReport 2")
+end


### PR DESCRIPTION
## What
- Adds line report associations to the User model so that a user can have a line manager and many line reports
- Adds a LineReports controller with show method and associated routing
- Refactors the navigation bar to allow conditional rendering of options depending on user's state
- Populates line_reports#show with template content (non-functional)
## Why
This lays the foundation for features such as line managers managing annual leave requests.

## Screenshots
### Line reports dashboard
![localhost_3000_line_reports(iPad Pro)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/01913d61-569f-4840-96e3-852509bcd6ef)

### Design specification
![localhost_3000_line-reports(iPad Pro)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/c8946ee0-8919-4216-a22d-c4a92480d476)
