### PR TITLE
Add working days calculator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.2.2"
 gem "rails", "~> 7.0.7"
 
 gem "bootsnap", require: false
+gem "business"
 gem "devise"
 gem "govuk_app_config"
 gem "govuk_publishing_components"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     builder (3.2.4)
     buildkite-test_collector (2.3.1)
       activesupport (>= 4.2)
+    business (2.3.0)
     byebug (11.1.3)
     capybara (3.39.2)
       addressable
@@ -550,6 +551,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   buildkite-test_collector
+  business
   devise
   factory_bot_rails
   govuk_app_config

--- a/app/services/working_days_calculator.rb
+++ b/app/services/working_days_calculator.rb
@@ -1,0 +1,25 @@
+class WorkingDaysCalculator
+  attr_reader :date_from, :date_to
+
+  def initialize(date_from, date_to)
+    @date_from = date_from
+    @date_to = date_to
+  end
+
+  def number_of_working_days
+    calendar.business_days_between(date_from, date_to + 1)
+  end
+
+  def bank_holidays
+    if date_from.year != date_to.year
+      BankHolidayGenerator.new(date_from.year).list_of_bank_holidays +
+        BankHolidayGenerator.new(date_to.year).list_of_bank_holidays
+    else
+      BankHolidayGenerator.new(date_from.year).list_of_bank_holidays
+    end
+  end
+
+  def calendar
+    @calendar ||= Business::Calendar.new(holidays: bank_holidays)
+  end
+end

--- a/spec/services/working_days_calculator_spec.rb
+++ b/spec/services/working_days_calculator_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe WorkingDaysCalculator, type: :model do
+  describe "#number_of_working_days" do
+    context "when annual leave is contained within the same year" do
+      it "omits weekends" do
+        # Dates including a non-bank holiday weekend
+        date_from = Date.civil(2023, 8, 9)
+        date_to = Date.civil(2023, 8, 14)
+        expected_output = 4
+        output = described_class.new(date_from, date_to).number_of_working_days
+        expect(output).to eq(expected_output)
+      end
+
+      it "omits bank holidays" do
+        # Mid-week dates including 28th August bank holiday (no weekend days)
+        date_from = Date.civil(2023, 8, 28)
+        date_to = Date.civil(2023, 9, 1)
+        expected_output = 4
+        output = described_class.new(date_from, date_to).number_of_working_days
+        expect(output).to eq(expected_output)
+      end
+    end
+
+    context "when annual leave spans multiple years" do
+      it "omits bank holidays from both years" do
+        # Dates spanning Christmas and New Years bank holidays
+        date_from = Date.civil(2023, 12, 25)
+        date_to = Date.civil(2024, 1, 5)
+        expected_output = 7
+        output = described_class.new(date_from, date_to).number_of_working_days
+        expect(output).to eq(expected_output)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
- Creates a class for calculating working days between two dates (i.e. excluding bank holidays and weekends) using the `business` gem

## Why
This will be used when a user requests annual leave to calculate how many days annual leave they need to take for their given dates, and enables comparison with the user's remaining annual leave.