### PR TITLE
Functionality: User can view annual leave requests on dashboard

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,5 +1,12 @@
 class RootController < ApplicationController
+  before_action :redirect_if_user_not_signed_in
+
   def index
+  end
+
+private
+
+  def redirect_if_user_not_signed_in
     redirect_to new_user_session_path unless current_user
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -2,6 +2,7 @@ class RootController < ApplicationController
   before_action :redirect_if_user_not_signed_in
 
   def index
+    @annual_leave_requests = current_user.annual_leave_requests.sort_by(&:date_from)
   end
 
 private

--- a/app/helpers/root_helper.rb
+++ b/app/helpers/root_helper.rb
@@ -1,0 +1,12 @@
+module RootHelper
+  def formatted_status(status)
+    case status
+    when "pending"
+      sanitize("<strong class='govuk-tag govuk-tag--yellow'> #{status} </strong>")
+    when "approved"
+      sanitize("<strong class='govuk-tag govuk-tag--green'> #{status} </strong>")
+    when "withdrawn", "denied"
+      sanitize("<strong class='govuk-tag govuk-tag--red'> #{status} </strong>")
+    end
+  end
+end

--- a/app/views/root/_annual_leave_request_card.html.erb
+++ b/app/views/root/_annual_leave_request_card.html.erb
@@ -1,0 +1,47 @@
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Annual leave request"
+    } %>
+    <ul class="govuk-summary-card__actions">
+      <li class="govuk-summary-card__action"> <a class="govuk-link" href="#">
+          Edit
+          <span class="govuk-visually-hidden">
+            <%= annual_leave_request.status %> annual leave request from 
+            <%= annual_leave_request.date_from %> to <%= annual_leave_request.date_to %>
+          </span>
+        </a>
+      </li>
+      <li class="govuk-summary-card__action"> <a class="govuk-link" href="#">
+          Withdraw
+          <span class="govuk-visually-hidden">
+            <%= annual_leave_request.status %> annual leave request from 
+            <%= annual_leave_request.date_from %> to <%= annual_leave_request.date_to %>
+          </span>
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="govuk-summary-card__content">
+    <%= render "govuk_publishing_components/components/summary_list", {
+      items: [
+        {
+          field: "Status",
+          value: formatted_status(annual_leave_request.status)
+        },
+        {
+          field: "Date from",
+          value: annual_leave_request.date_from.to_fs(:rfc822)
+        },
+        {
+          field: "Date to",
+          value: annual_leave_request.date_to.to_fs(:rfc822)
+        },
+        {
+          field: "Number of days",
+          value: annual_leave_request.days_required
+        }
+      ]
+    } %>
+  </div>
+</div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -16,4 +16,9 @@
   rel: "external"
 } %>
 
+<div class="govuk-!-margin-top-6">
+  <% @annual_leave_requests.each do |annual_leave_request| %>
+    <%= render "annual_leave_request_card", annual_leave_request: %>
+  <% end %>
+<div>
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ GovukTest.configure
 
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include FactoryBot::Syntax::Methods
   config.expose_dsl_globally = false

--- a/spec/views/root/index.html.erb_spec.rb
+++ b/spec/views/root/index.html.erb_spec.rb
@@ -19,5 +19,45 @@ RSpec.describe "root/index", type: :view do
       expect(rendered).to have_content(annual_leave_request.date_to.to_fs(:rfc822))
       expect(rendered).to have_content(annual_leave_request.days_required.to_s)
     end
+
+    it "renders the correct css tag for pending leave" do
+      create(:annual_leave_request, user_id: user.id, status: "pending")
+      assign(:annual_leave_requests, user.annual_leave_requests)
+
+      render
+
+      expect(rendered).to have_content("pending")
+      expect(rendered).to have_css(".govuk-tag--yellow")
+    end
+
+    it "renders the correct css tag for approved leave" do
+      create(:annual_leave_request, user_id: user.id, status: "approved")
+      assign(:annual_leave_requests, user.annual_leave_requests)
+
+      render
+
+      expect(rendered).to have_content("approved")
+      expect(rendered).to have_css(".govuk-tag--green")
+    end
+
+    it "renders the correct css tag for withdrawn leave" do
+      create(:annual_leave_request, user_id: user.id, status: "withdrawn")
+      assign(:annual_leave_requests, user.annual_leave_requests)
+
+      render
+
+      expect(rendered).to have_content("withdrawn")
+      expect(rendered).to have_css(".govuk-tag--red")
+    end
+
+    it "renders the correct css tag for denied leave" do
+      create(:annual_leave_request, user_id: user.id, status: "denied")
+      assign(:annual_leave_requests, user.annual_leave_requests)
+
+      render
+
+      expect(rendered).to have_content("denied")
+      expect(rendered).to have_css(".govuk-tag--red")
+    end
   end
 end

--- a/spec/views/root/index.html.erb_spec.rb
+++ b/spec/views/root/index.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe "root/index", type: :view do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  context "when a user has annual leave requests" do
+    it "renders each request in a card" do
+      annual_leave_request = create(:annual_leave_request, user_id: user.id)
+      assign(:annual_leave_requests, user.annual_leave_requests)
+
+      render
+
+      expect(rendered).to have_content(annual_leave_request.status.to_s)
+      expect(rendered).to have_content(annual_leave_request.date_from.to_fs(:rfc822))
+      expect(rendered).to have_content(annual_leave_request.date_to.to_fs(:rfc822))
+      expect(rendered).to have_content(annual_leave_request.days_required.to_s)
+    end
+  end
+end


### PR DESCRIPTION
# What
- Adds functionality to the user dashboard so that users can view their existing annual leave requests

# Screenshots
## Dashboard
![localhost_3000_(iPad Pro) (7) (1)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/2a6bf596-9410-431c-9b83-617311e355e7)
## Design specification
![localhost_3000_dashboard(iPad Pro) (2)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/8141ac3b-c709-4a61-9458-8a625afd9c9b)
