### PR TITLE
Fix annual_leave_request resource

### DIFF
--- a/app/controllers/annual_leave_requests_controller.rb
+++ b/app/controllers/annual_leave_requests_controller.rb
@@ -13,7 +13,7 @@ class AnnualLeaveRequestsController < ApplicationController
     @annual_leave_request = current_user.annual_leave_requests.build(annual_leave_request_params)
 
     if @annual_leave_request.save
-      redirect_to annual_leave_requests_confirmation_path
+      redirect_to annual_leave_request_confirmation_path
     else
       render "new"
     end

--- a/app/views/annual_leave_requests/new.html.erb
+++ b/app/views/annual_leave_requests/new.html.erb
@@ -17,7 +17,7 @@
       average_title_length: "long",
     } %>
 
-    <%= form_with url: annual_leave_requests_check_path, method: :get do %>
+    <%= form_with url: check_annual_leave_request_path, method: :get do %>
       <%= render "govuk_publishing_components/components/label", {
         text: "Date from:",
         html_for: "annual_leave_request[date_from]",

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -11,7 +11,7 @@
 
 <%= render "govuk_publishing_components/components/button", {
   text: "Request annual leave",
-  href: new_annual_leave_requests_path,
+  href: new_annual_leave_request_path,
   start: true,
   rel: "external"
 } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,9 @@ Rails.application.routes.draw do
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
 
   resource :line_reports, only: [:show]
-  resource :annual_leave_requests, only: %i[new create]
-  get "/annual_leave_requests/check", to: "annual_leave_requests#check"
-  get "/annual_leave_requests/confirmation", to: "annual_leave_requests#confirm"
+  resources :annual_leave_requests, only: %i[new create]
+  get "/annual_leave_requests/check", to: "annual_leave_requests#check", as: "check_annual_leave_request"
+  get "/annual_leave_requests/confirmation", to: "annual_leave_requests#confirm", as: "annual_leave_request_confirmation"
 
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 end

--- a/spec/controllers/annual_leave_requests_controller_spec.rb
+++ b/spec/controllers/annual_leave_requests_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AnnualLeaveRequestsController do
         date_to: valid_request.date_to,
         days_required: valid_request.days_required,
       } }
-      expect(response).to redirect_to(annual_leave_requests_confirmation_path)
+      expect(response).to redirect_to(annual_leave_request_confirmation_path)
     end
 
     it "redirects to new page if annual leave request invalid" do


### PR DESCRIPTION
# What
Routes was previously using the `resource:` syntax which doesn't support access to database entries via ID (e.g. the path `annual_leave_requests/1/edit`). This PR updates the routes to make use of the`resources:` syntax which does support this. It also updates path names to their new values as these changed as result of the update (e.g. `new_annual_leave_requests_path` => `new_annual_leave_request_path`).

# Why
This change will make it easier to complete upcoming work relating to editing and withdrawing annual leave requests via the dashboard.