### PR TITLE
Feature: Line manager can deny an annual leave request

### DIFF
--- a/app/controllers/annual_leave_requests_controller.rb
+++ b/app/controllers/annual_leave_requests_controller.rb
@@ -27,6 +27,11 @@ class AnnualLeaveRequestsController < ApplicationController
     @annual_leave_request = line_reports_leave_requests.find(params[:annual_leave_request_id])
   end
 
+  def deny
+    line_reports_leave_requests = AnnualLeaveRequest.where(user: current_user.line_reports)
+    @annual_leave_request = line_reports_leave_requests.find(params[:annual_leave_request_id])
+  end
+
   def update_status
     line_reports_leave_requests = AnnualLeaveRequest.where(user: current_user.line_reports)
     @annual_leave_request = line_reports_leave_requests.find(params[:annual_leave_request_id])

--- a/app/controllers/annual_leave_requests_controller.rb
+++ b/app/controllers/annual_leave_requests_controller.rb
@@ -59,7 +59,7 @@ private
   end
 
   def annual_leave_request_params
-    params.require(:annual_leave_request).permit(:date_from, :date_to, :days_required, :status, :confirm_approval)
+    params.require(:annual_leave_request).permit(:date_from, :date_to, :days_required, :status, :confirm_approval, :denial_reason)
   end
 
   def redirect_to_status_update_confirmation_page

--- a/app/controllers/annual_leave_requests_controller.rb
+++ b/app/controllers/annual_leave_requests_controller.rb
@@ -37,8 +37,8 @@ class AnnualLeaveRequestsController < ApplicationController
     @annual_leave_request = line_reports_leave_requests.find(params[:annual_leave_request_id])
 
     if @annual_leave_request.update(annual_leave_request_params)
-      send_status_update_email
-      redirect_to_status_update_confirmation_page
+      helpers.send_status_updated_email(@annual_leave_request)
+      redirect_to status_update_confirmation_page
     else
       render "approve" if annual_leave_request_params[:status] == "approved"
       render "deny" if annual_leave_request_params[:status] == "denied"
@@ -63,21 +63,12 @@ private
     params.require(:annual_leave_request).permit(:date_from, :date_to, :days_required, :status, :confirm_approval, :denial_reason)
   end
 
-  def send_status_update_email
+  def status_update_confirmation_page
     case annual_leave_request_params[:status]
     when "approved"
-      helpers.send_approved_request_email(@annual_leave_request)
+      confirm_annual_leave_request_approval_path
     when "denied"
-      helpers.send_denied_request_email(@annual_leave_request)
-    end
-  end
-
-  def redirect_to_status_update_confirmation_page
-    case annual_leave_request_params[:status]
-    when "approved"
-      redirect_to confirm_annual_leave_request_approval_path
-    when "denied"
-      redirect_to confirm_annual_leave_request_denial_path
+      confirm_annual_leave_request_denial_path
     end
   end
 end

--- a/app/controllers/annual_leave_requests_controller.rb
+++ b/app/controllers/annual_leave_requests_controller.rb
@@ -40,7 +40,8 @@ class AnnualLeaveRequestsController < ApplicationController
       helpers.send_approved_request_email(@annual_leave_request)
       redirect_to_status_update_confirmation_page
     else
-      render "approve"
+      render "approve" if annual_leave_request_params[:status] == "approved"
+      render "deny" if annual_leave_request_params[:status] == "denied"
     end
   end
 

--- a/app/controllers/annual_leave_requests_controller.rb
+++ b/app/controllers/annual_leave_requests_controller.rb
@@ -37,7 +37,7 @@ class AnnualLeaveRequestsController < ApplicationController
     @annual_leave_request = line_reports_leave_requests.find(params[:annual_leave_request_id])
 
     if @annual_leave_request.update(annual_leave_request_params)
-      helpers.send_approved_request_email(@annual_leave_request)
+      send_status_update_email
       redirect_to_status_update_confirmation_page
     else
       render "approve" if annual_leave_request_params[:status] == "approved"
@@ -61,6 +61,15 @@ private
 
   def annual_leave_request_params
     params.require(:annual_leave_request).permit(:date_from, :date_to, :days_required, :status, :confirm_approval, :denial_reason)
+  end
+
+  def send_status_update_email
+    case annual_leave_request_params[:status]
+    when "approved"
+      helpers.send_approved_request_email(@annual_leave_request)
+    when "denied"
+      helpers.send_denied_request_email(@annual_leave_request)
+    end
   end
 
   def redirect_to_status_update_confirmation_page

--- a/app/controllers/annual_leave_requests_controller.rb
+++ b/app/controllers/annual_leave_requests_controller.rb
@@ -38,13 +38,15 @@ class AnnualLeaveRequestsController < ApplicationController
 
     if @annual_leave_request.update(annual_leave_request_params)
       helpers.send_approved_request_email(@annual_leave_request)
-      redirect_to confirm_annual_leave_request_approval_path
+      redirect_to_status_update_confirmation_page
     else
       render "approve"
     end
   end
 
   def confirm_approval; end
+
+  def confirm_denial; end
 
 private
 
@@ -58,5 +60,14 @@ private
 
   def annual_leave_request_params
     params.require(:annual_leave_request).permit(:date_from, :date_to, :days_required, :status, :confirm_approval)
+  end
+
+  def redirect_to_status_update_confirmation_page
+    case annual_leave_request_params[:status]
+    when "approved"
+      redirect_to confirm_annual_leave_request_approval_path
+    when "denied"
+      redirect_to confirm_annual_leave_request_denial_path
+    end
   end
 end

--- a/app/helpers/emails_helper.rb
+++ b/app/helpers/emails_helper.rb
@@ -16,37 +16,13 @@ module EmailsHelper
     )
   end
 
-  def send_approved_request_email(annual_leave_request)
-    user = annual_leave_request.user
-    line_manager = user.line_manager
-
-    client.send_email(
-      email_address: user.email,
-      template_id: "34542d49-8b91-412c-9393-c186a04a7d1c",
-      personalisation: {
-        line_manager_name: "#{line_manager.given_name} #{line_manager.family_name}",
-        name: "#{user.given_name} #{user.family_name}",
-        date_from: annual_leave_request.date_from.to_fs(:rfc822),
-        date_to: annual_leave_request.date_to.to_fs(:rfc822),
-      },
-    )
-  end
-
-  def send_denied_request_email(annual_leave_request)
-    user = annual_leave_request.user
-    line_manager = user.line_manager
-
-    client.send_email(
-      email_address: user.email,
-      template_id: "ec9035df-9c98-4e0e-8826-47768c311745",
-      personalisation: {
-        line_manager_name: "#{line_manager.given_name} #{line_manager.family_name}",
-        name: "#{user.given_name} #{user.family_name}",
-        date_from: annual_leave_request.date_from.to_fs(:rfc822),
-        date_to: annual_leave_request.date_to.to_fs(:rfc822),
-        denial_reason: annual_leave_request.denial_reason,
-      },
-    )
+  def send_status_updated_email(annual_leave_request)
+    case annual_leave_request.status
+    when "approved"
+      client.send_email(approval_email_hash(annual_leave_request))
+    when "denied"
+      client.send_email(denial_email_hash(annual_leave_request))
+    end
   end
 
 private
@@ -57,5 +33,36 @@ private
 
   def notify_api_key
     ENV["NOTIFY_API_KEY"]
+  end
+
+  def approval_email_hash(annual_leave_request)
+    user = annual_leave_request.user
+    line_manager = user.line_manager
+    {
+      email_address: user.email,
+      template_id: "34542d49-8b91-412c-9393-c186a04a7d1c",
+      personalisation: {
+        line_manager_name: "#{line_manager.given_name} #{line_manager.family_name}",
+        name: "#{user.given_name} #{user.family_name}",
+        date_from: annual_leave_request.date_from.to_fs(:rfc822),
+        date_to: annual_leave_request.date_to.to_fs(:rfc822),
+      },
+    }
+  end
+
+  def denial_email_hash(annual_leave_request)
+    user = annual_leave_request.user
+    line_manager = user.line_manager
+    {
+      email_address: user.email,
+      template_id: "ec9035df-9c98-4e0e-8826-47768c311745",
+      personalisation: {
+        line_manager_name: "#{line_manager.given_name} #{line_manager.family_name}",
+        name: "#{user.given_name} #{user.family_name}",
+        date_from: annual_leave_request.date_from.to_fs(:rfc822),
+        date_to: annual_leave_request.date_to.to_fs(:rfc822),
+        denial_reason: annual_leave_request.denial_reason,
+      },
+    }
   end
 end

--- a/app/helpers/emails_helper.rb
+++ b/app/helpers/emails_helper.rb
@@ -32,6 +32,23 @@ module EmailsHelper
     )
   end
 
+  def send_denied_request_email(annual_leave_request)
+    user = annual_leave_request.user
+    line_manager = user.line_manager
+
+    client.send_email(
+      email_address: user.email,
+      template_id: "ec9035df-9c98-4e0e-8826-47768c311745",
+      personalisation: {
+        line_manager_name: "#{line_manager.given_name} #{line_manager.family_name}",
+        name: "#{user.given_name} #{user.family_name}",
+        date_from: annual_leave_request.date_from.to_fs(:rfc822),
+        date_to: annual_leave_request.date_to.to_fs(:rfc822),
+        denial_reason: annual_leave_request.denial_reason,
+      },
+    )
+  end
+
 private
 
   def client

--- a/app/models/annual_leave_request.rb
+++ b/app/models/annual_leave_request.rb
@@ -6,6 +6,7 @@ class AnnualLeaveRequest < ApplicationRecord
   validates :date_from, :date_to, comparison: { greater_than: Time.zone.today, message: "must be in the future" }
   validate :user_has_enough_annual_leave_remaining
   validates :confirm_approval, acceptance: { accept: "confirmed" }
+  validates :denial_reason, presence: true, allow_nil: true
 
 private
 

--- a/app/views/annual_leave_requests/approve.html.erb
+++ b/app/views/annual_leave_requests/approve.html.erb
@@ -4,6 +4,14 @@
       href: "javascript:window.history.back()"
     } %>
 
+    <% if @annual_leave_request.errors.any? %>
+      <%= render "govuk_publishing_components/components/error_summary", {
+        title: "There was a problem with your approval",
+        description: "Fix the following issue(s) and re-submit your request",
+        items: error_messages_for(@annual_leave_request)
+      } %>
+    <% end %>
+
     <%= render "govuk_publishing_components/components/title", {
       title: "Approve annual leave request",
       average_title_length: "long",

--- a/app/views/annual_leave_requests/confirm_denial.html.erb
+++ b/app/views/annual_leave_requests/confirm_denial.html.erb
@@ -1,0 +1,38 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel" style="background-color: #d4351c">
+      <h1 class="govuk-panel__title" style="color: white">
+        Annual leave request denied
+      </h1>
+      <div class="govuk-panel__body" style="color: white">
+        The status will be automatically updated for your line report
+      </div>
+    </div>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "What happens next?",
+      padding: true
+    } %>
+
+    <p class="govuk-body"> 
+      Your line report will be notified of your response via email and their request 
+      status will be updated on their dashboard.
+    </p>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "If you didn't mean to deny this request",
+      padding: true
+    } %>
+
+    <p class="govuk-body">
+      If you have denied this request in error, please contact an administrator
+      immediately.
+    </p>
+    <p class="govuk-body">
+      Administrators can be contacted via email (admins-holiday-logger@digital.cabinet-office.gov.uk)
+      or on the #holiday-logger Slack channel
+    </p>
+
+    <%= link_to "Go back to line report dashboard", line_reports_path, html_options = { class: "govuk-link" }%>
+  </div>
+</div>

--- a/app/views/annual_leave_requests/deny.html.erb
+++ b/app/views/annual_leave_requests/deny.html.erb
@@ -9,13 +9,22 @@
       average_title_length: "long",
     } %>
 
+    <% if @annual_leave_request.errors.any? %>
+      <%= render "govuk_publishing_components/components/error_summary", {
+        title: "There was a problem with your denial",
+        description: "Fix the following issue(s) and re-submit your response",
+        items: error_messages_for(@annual_leave_request)
+      } %>
+    <% end %>
+
     <%= form_with url: annual_leave_request_update_status_path(@annual_leave_request), method: :patch do |f| %>
       <%= hidden_field(:annual_leave_request, :status, value: "denied") %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Please write the reason for denying this annual leave in the box below."
         },
-        name: "annual_leave_request[denial_reason]"
+        name: "annual_leave_request[denial_reason]",
+        error_message: error_message_for_input(@annual_leave_request.errors, :denial_reason),
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/annual_leave_requests/deny.html.erb
+++ b/app/views/annual_leave_requests/deny.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: "javascript:window.history.back()"
+    } %>
+
+    <%= render "govuk_publishing_components/components/title", {
+      title: "Deny annual leave request",
+      average_title_length: "long",
+    } %>
+
+    <%= form_with url: annual_leave_request_update_status_path(@annual_leave_request), method: :patch do |f| %>
+      <%= hidden_field(:annual_leave_request, :status, value: "denied") %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Please write the reason for denying this annual leave in the box below."
+        },
+        name: "annual_leave_request[denial_reason]"
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Deny leave",
+        destructive: true
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/line_reports/_approve_or_deny_links.html.erb
+++ b/app/views/line_reports/_approve_or_deny_links.html.erb
@@ -8,7 +8,7 @@
   </a>
   </li>
   <li class="govuk-summary-card__action">
-  <a class="govuk-link" href="#">
+  <a class="govuk-link" href=<%= annual_leave_request_deny_path(annual_leave_request)%>>
     Deny
     <span class="govuk-visually-hidden">
       <%= annual_leave_request.status %> annual leave request from 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :annual_leave_requests, only: %i[new create] do
     get "approve"
     patch "update_status"
+    get "deny"
   end
   get "/annual_leave_requests/check", to: "annual_leave_requests#check", as: "check_annual_leave_request"
   get "/annual_leave_requests/confirmation", to: "annual_leave_requests#confirm", as: "annual_leave_request_confirmation"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get "/annual_leave_requests/check", to: "annual_leave_requests#check", as: "check_annual_leave_request"
   get "/annual_leave_requests/confirmation", to: "annual_leave_requests#confirm", as: "annual_leave_request_confirmation"
   get "/annual_leave_requests/approval_confirmation", to: "annual_leave_requests#confirm_approval", as: "confirm_annual_leave_request_approval"
+  get "/annual_leave_requests/denial_confirmation", to: "annual_leave_requests#confirm_denial", as: "confirm_annual_leave_request_denial"
 
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 end

--- a/db/migrate/20230907121311_add_denial_reason_to_annual_leave_request.rb
+++ b/db/migrate/20230907121311_add_denial_reason_to_annual_leave_request.rb
@@ -1,0 +1,5 @@
+class AddDenialReasonToAnnualLeaveRequest < ActiveRecord::Migration[7.0]
+  def change
+    add_column :annual_leave_requests, :denial_reason, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_30_095326) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_121311) do
   create_table "annual_leave_requests", force: :cascade do |t|
     t.string "status", default: "pending"
     t.date "date_from"
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_30_095326) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "denial_reason"
     t.index ["user_id"], name: "index_annual_leave_requests_on_user_id"
   end
 

--- a/spec/controllers/annual_leave_requests_controller_spec.rb
+++ b/spec/controllers/annual_leave_requests_controller_spec.rb
@@ -52,15 +52,28 @@ RSpec.describe AnnualLeaveRequestsController do
       sign_in line_manager
     end
 
-    it "renders the approve page if status update is unsuccessful" do
+    it "renders the approve page if a status update to 'approved' is unsuccessful" do
       patch :update_status, params: {
         annual_leave_request_id: leave_request.id,
         annual_leave_request: {
           confirm_approval: "unconfirmed",
+          status: "approved",
         },
       }
 
       expect(response).to render_template(:approve)
+    end
+
+    it "renders the deny page if a status update to 'denied' is unsuccessful" do
+      patch :update_status, params: {
+        annual_leave_request_id: leave_request.id,
+        annual_leave_request: {
+          denial_reason: "",
+          status: "denied",
+        },
+      }
+
+      expect(response).to render_template(:deny)
     end
 
     it "sends an email to the line report when status is updated to approved" do

--- a/spec/features/line_manager/deny_annual_leave_request_spec.rb
+++ b/spec/features/line_manager/deny_annual_leave_request_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+RSpec.feature "Line manager can deny an annual leave request" do
+  setup do
+    notify_test_client = Notifications::Client.new(ENV["NOTIFY_TEST_API_KEY"])
+    allow_any_instance_of(EmailsHelper).to receive(:client).and_return(notify_test_client) # rubocop:disable RSpec/AnyInstance
+  end
+
+  scenario do
+    given_i_am_signed_in_as_a_line_manager
+    and_my_line_report_has_a_pending_leave_request
+    when_i_visit_the_line_reports_dashboard
+    and_i_click_manage_requests
+    and_i_deny_the_pending_request
+    then_the_request_status_updates_to_denied
+  end
+
+  def given_i_am_signed_in_as_a_line_manager
+    @line_manager = create(:user)
+    @line_report = create(:user, line_manager_id: @line_manager.id)
+    sign_in @line_manager
+  end
+
+  def and_my_line_report_has_a_pending_leave_request
+    @pending_request = create(:annual_leave_request, user_id: @line_report.id)
+    assert(@pending_request.status, "pending")
+  end
+
+  def when_i_visit_the_line_reports_dashboard
+    visit root_path
+    click_link "Your line reports"
+  end
+
+  def and_i_click_manage_requests
+    click_link "Manage requests"
+    expect(page).to have_content("#{@line_report.given_name} #{@line_report.family_name}")
+  end
+
+  def and_i_deny_the_pending_request
+    click_link "Deny"
+    expect(page).to have_content("Deny annual leave request")
+
+    fill_in "annual_leave_request[denial_reason]", with: "some valid reason"
+    click_button "Deny leave"
+  end
+
+  def then_the_request_status_updates_to_denied
+    expect(page).to have_content("Annual leave request denied")
+    @pending_request.reload
+    expect(@pending_request.status).to eq("denied")
+    expect(@pending_request.denial_reason).to eq("some valid reason")
+  end
+end

--- a/spec/helpers/emails_helper_spec.rb
+++ b/spec/helpers/emails_helper_spec.rb
@@ -18,28 +18,28 @@ RSpec.describe EmailsHelper, type: :helper do
     end
   end
 
-  describe "#send_approved_request_email" do
-    it "sends an approval email to the user" do
+  describe "#send_status_updated_email" do
+    it "sends a denial email to the user when status is updated to 'denied'" do
       @client = Notifications::Client.new(ENV["NOTIFY_TEST_API_KEY"])
-
-      response_notification = helper.send_approved_request_email(annual_leave_request)
-      response = client.get_notification(response_notification.id)
-
-      expect(response.email_address).to eq(user.email)
-      expect(response.subject).to eq("GOV.UK Holiday Logger – Annual Leave Request Approved")
-    end
-  end
-
-  describe "#send_denied_request_email" do
-    it "sends a denial email to the user" do
-      @client = Notifications::Client.new(ENV["NOTIFY_TEST_API_KEY"])
+      annual_leave_request.status = "denied"
       annual_leave_request.denial_reason = "some reason"
 
-      response_notification = helper.send_denied_request_email(annual_leave_request)
+      response_notification = helper.send_status_updated_email(annual_leave_request)
       response = client.get_notification(response_notification.id)
 
       expect(response.email_address).to eq(user.email)
       expect(response.subject).to eq("GOV.UK Holiday Logger – Annual Leave Request Denied")
+    end
+
+    it "sends an approval email to the user when status is updated to 'approved'" do
+      @client = Notifications::Client.new(ENV["NOTIFY_TEST_API_KEY"])
+      annual_leave_request.status = "approved"
+
+      response_notification = helper.send_status_updated_email(annual_leave_request)
+      response = client.get_notification(response_notification.id)
+
+      expect(response.email_address).to eq(user.email)
+      expect(response.subject).to eq("GOV.UK Holiday Logger – Annual Leave Request Approved")
     end
   end
 end

--- a/spec/helpers/emails_helper_spec.rb
+++ b/spec/helpers/emails_helper_spec.rb
@@ -29,4 +29,17 @@ RSpec.describe EmailsHelper, type: :helper do
       expect(response.subject).to eq("GOV.UK Holiday Logger – Annual Leave Request Approved")
     end
   end
+
+  describe "#send_denied_request_email" do
+    it "sends a denial email to the user" do
+      @client = Notifications::Client.new(ENV["NOTIFY_TEST_API_KEY"])
+      annual_leave_request.denial_reason = "some reason"
+
+      response_notification = helper.send_denied_request_email(annual_leave_request)
+      response = client.get_notification(response_notification.id)
+
+      expect(response.email_address).to eq(user.email)
+      expect(response.subject).to eq("GOV.UK Holiday Logger – Annual Leave Request Denied")
+    end
+  end
 end

--- a/spec/views/annual_leave_requests/deny.html.erb_spec.rb
+++ b/spec/views/annual_leave_requests/deny.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe "annual_leave_requests/deny", type: :view do
+  let(:user) { create(:user) }
+
+  context "when there are errors present" do
+    it "renders the error summary and errors on the input field" do
+      invalid_leave_request = create(:annual_leave_request, user_id: user.id)
+      invalid_leave_request.errors.add(:denial_reason, "error 1")
+      assign(:annual_leave_request, invalid_leave_request)
+
+      render
+
+      expect(rendered).to have_content("Fix the following issue(s) and re-submit your response")
+      expect(rendered).to have_css("p.govuk-error-message", text: "Denial reason error 1")
+    end
+  end
+
+  context "when there are no errors present" do
+    it "doesn't render the error summary" do
+      assign(:annual_leave_request, create(:annual_leave_request, user_id: user.id))
+
+      render
+
+      expect(rendered).not_to have_content("Fix the following issue(s) and re-submit your request")
+    end
+  end
+end


### PR DESCRIPTION
# What

Adds the ability for line managers to deny annual leave requests, including:

- Feature test following the full user journey
- Error handling on the annual_leave_requests#deny page when a line manager does not give a reason for denying the annual leave request.
- Sending an email when a user's annual leave request has been denied
- **NOTE:** The email address and Slack channel on the annual_leave_request#confirm_approval page are non-functional at the moment so are not links.

# Why
This is a key feature in the application. Users need to have their annual leave requests responded to by their line managers.

# Screenshots
## Deny page
![localhost_3000_annual_leave_requests_4_deny(iPad Pro)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/b4a4bc64-a571-4715-b6c7-c205c2b21e49)

## Design specification
![Deny ALR check_reason](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/dbd7ca5f-85d4-4c16-b39e-9dd35eb0af11)

## Deny page with errors
![localhost_3000_annual_leave_requests_4_update_status(iPad Pro)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/26895a8b-f02a-46fe-88d5-6b558af70af0)

## Denial confirmation page
![localhost_3000_annual_leave_requests_denial_confirmaiton(iPad Pro)](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/efdfa3bd-0855-47e1-a31c-da288e36f912)

## Design specification
![Deny ALR confirmation](https://github.com/jyoung-gds/govuk-holiday-logger/assets/94846816/9cf4e1fd-cf84-4196-b3c5-ac48bac2a712)
