### PR TITLE
Fix date_from validations

### DIFF
--- a/app/models/annual_leave_request.rb
+++ b/app/models/annual_leave_request.rb
@@ -2,7 +2,7 @@ class AnnualLeaveRequest < ApplicationRecord
   belongs_to :user
 
   validates :date_from, :date_to, :days_required, presence: true
-  validates :date_from, comparison: { less_than: :date_to, message: "must be before Date to" }
+  validates :date_from, comparison: { less_than_or_equal_to: :date_to, message: "must be the same as or before Date to" }
   validates :date_from, :date_to, comparison: { greater_than: Time.zone.today, message: "must be in the future" }
   validate :user_has_enough_annual_leave_remaining
   validates :confirm_approval, acceptance: { accept: "confirmed" }


### PR DESCRIPTION
As dates are inclusive, `date_to` and `date_from` can be equal (when requesting 1 day of annual leave). Therefore, this validation needs to be updated.