### PR TITLE
Fix line manager name interpolation

### DIFF
--- a/app/views/annual_leave_requests/confirm.html.erb
+++ b/app/views/annual_leave_requests/confirm.html.erb
@@ -12,7 +12,7 @@
 
     <p class="govuk-body"> 
       We've sent your request via email to your line manager 
-      <%= "(#{current_user.line_manager})" if current_user.line_manager %> and 
+      <%= "(#{current_user.line_manager.given_name} #{current_user.line_manager.family_name})" if current_user.line_manager %> and 
       delivery manager 
       <% # TODO: Interpolate delivery manager's name %>
       for approval.


### PR DESCRIPTION
The current interpolation just outputs the User object, this updates it to give the line manager's name.